### PR TITLE
Create Paristuan travel planner single-page site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Paristuan: Curated Paris Travel Planner
+
+Paristuan is a lightweight single-page web experience that helps travelers curate a boutique getaway in Paris. The project focuses on storytelling and trip organization so visitors can explore inspiration, assemble a personalized itinerary, and review insider tips in one place.
+
+## Features
+- **Story-driven landing page** with a hero introduction, immersive imagery, and prominent call-to-action.
+- **Experience explorer** with category filters that surface curated cultural, culinary, and art activities.
+- **Interactive itinerary planner** allowing visitors to add plans for specific days and times, automatically sorted and removable.
+- **Neighborhood spotlight** cards that reveal details when selected, encouraging deeper discovery.
+- **Local insight section** highlighting travel tips and practical information.
+- **Responsive layout** that adapts cleanly from mobile to desktop viewports.
+
+## Tech stack
+- Semantic HTML5 structure.
+- Modern CSS with custom properties, flexbox, and grid layout.
+- Vanilla JavaScript for state management, filtering, itinerary persistence, and UI interactions (no external frameworks required).
+
+## Getting started
+1. Open `index.html` in any modern browser. All assets load locally or from public CDNs.
+2. Interact with the filters to browse experiences.
+3. Use the itinerary form to build a personalized schedule.
+
+No build step is required. To develop further, edit the HTML/CSS/JS files directly.
+
+## Project structure
+```
+├── README.md
+├── index.html
+├── styles.css
+└── app.js
+```
+
+## Future enhancements
+- Persist itinerary items to a backend service or calendar export.
+- Integrate an actual map service for the neighborhood explorer.
+- Expand curated experiences with API-driven content.
+
+Enjoy crafting your dream Paris itinerary with Paristuan!

--- a/app.js
+++ b/app.js
@@ -1,0 +1,347 @@
+const experienceData = [
+  {
+    id: 'atelier-savor',
+    title: 'Atelier fragrance workshop',
+    category: 'art',
+    duration: '2 hrs',
+    description:
+      'Blend a signature scent inside a Saint-Germain perfumery guided by a master nose.',
+    addOn: 'Pair with tea at Ladurée Bonaparte afterwards.'
+  },
+  {
+    id: 'canal-picnic',
+    title: 'Canal Saint-Martin picnic cruise',
+    category: 'cuisine',
+    duration: '3 hrs',
+    description:
+      'Float along the canal with a private chef-curated picnic and live accordion.',
+    addOn: 'Best at golden hour with chilled pét-nat.'
+  },
+  {
+    id: 'marais-gallery',
+    title: 'Le Marais gallery stroll',
+    category: 'art',
+    duration: '90 mins',
+    description:
+      'Meet gallerists showcasing contemporary art tucked away on cobblestoned rues.',
+    addOn: 'Request artist studio introductions in advance.'
+  },
+  {
+    id: 'latin-jazz',
+    title: 'Left Bank jazz & supper club',
+    category: 'nightlife',
+    duration: 'Evening',
+    description:
+      'Slip into a candlelit cellar for an intimate trio performance with a prix fixe menu.',
+    addOn: 'Arrive early for a martini at the bar upstairs.'
+  },
+  {
+    id: 'versailles-cycling',
+    title: 'Versailles estate cycling',
+    category: 'culture',
+    duration: 'Day trip',
+    description:
+      'Pedal through Versailles gardens, picnic on the Grand Canal, and tour the estate with a historian.',
+    addOn: 'Upgrade to a sunrise hot-air balloon preview.'
+  },
+  {
+    id: 'market-tasting',
+    title: 'Marché d’Aligre tasting trail',
+    category: 'cuisine',
+    duration: 'Morning',
+    description:
+      'Sample cheeses, oysters, and patisserie with a local gourmand through bustling stalls.',
+    addOn: 'Take notes for your market-inspired dinner.'
+  },
+  {
+    id: 'literary-salon',
+    title: 'Literary salon evening',
+    category: 'culture',
+    duration: '2 hrs',
+    description:
+      'Join a private reading and conversation in a Belle Époque apartment overlooking the Seine.',
+    addOn: 'Dress in cocktail attire for champagne toasts.'
+  }
+];
+
+const neighborhoods = [
+  {
+    id: 'montmartre',
+    name: 'Montmartre',
+    mood: 'Bohemian heights',
+    description:
+      'Artists at Place du Tertre, vintage cinemas, and sweeping dusk views crowned by Sacré-Cœur.',
+    highlight: 'Book a portrait session in a tucked-away atelier.'
+  },
+  {
+    id: 'saint-germain',
+    name: 'Saint-Germain-des-Prés',
+    mood: 'Intellectual romance',
+    description:
+      'Iconic cafés, jazz cellars, and antique bookstores where philosophers once scribbled.',
+    highlight: 'Order a café crème at Café de Flore before browsing rare editions next door.'
+  },
+  {
+    id: 'canal-north',
+    name: 'Canal Saint-Martin',
+    mood: 'Creative drift',
+    description:
+      'Design studios, wine bars, and leafy quays perfect for an afternoon people-watch.',
+    highlight: 'Pick up natural wine at La Buvette and settle on the locks for sunset.'
+  },
+  {
+    id: 'le-marais',
+    name: 'Le Marais',
+    mood: 'Fashioned history',
+    description:
+      'A tapestry of hôtels particuliers, fashion houses, and falafel joints in medieval lanes.',
+    highlight: 'Visit Musée Carnavalet then savor sablés from a 17th-century bakery.'
+  }
+];
+
+const surpriseItineraries = [
+  ['Sunrise espresso at Café Saint-Régis', 'Explore Musée d’Orsay impressionists', 'Picnic on Île de la Cité', 'Evening jazz at Duc des Lombards'],
+  ['Pain au chocolat breakfast in Le Marais', 'Atelier fragrance workshop', 'Vintage shopping on Rue des Martyrs', 'Dinner cruise on the Seine'],
+  ['Morning run along Canal Saint-Martin', 'Cooking class in Montorgueil', 'Contemporary art tour at Palais de Tokyo', 'Speakeasy cocktails in Pigalle']
+];
+
+const experienceGrid = document.querySelector('#experience-grid');
+const detailContainer = document.querySelector('#experience-details');
+const filterButtons = document.querySelectorAll('.filter-button');
+const planForm = document.querySelector('#plan-form');
+const itineraryList = document.querySelector('#itinerary-list');
+const itineraryEmpty = document.querySelector('#itinerary-empty');
+const plannerSummary = document.querySelector('#planner-summary');
+const surpriseButton = document.querySelector('#surprise-me');
+const yearSpan = document.querySelector('#year');
+const neighborhoodGrid = document.querySelector('#neighborhood-grid');
+
+let itineraryItems = [];
+
+const loadItinerary = () => {
+  try {
+    const stored = localStorage.getItem('paristuan-itinerary');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        itineraryItems = parsed;
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to load saved itinerary', error);
+  }
+};
+
+const saveItinerary = () => {
+  try {
+    localStorage.setItem('paristuan-itinerary', JSON.stringify(itineraryItems));
+  } catch (error) {
+    console.warn('Unable to save itinerary', error);
+  }
+};
+
+const experienceCard = (experience) => {
+  const card = document.createElement('article');
+  card.className = 'card';
+  card.innerHTML = `
+    <div class="meta">${experience.category}</div>
+    <h3>${experience.title}</h3>
+    <p>${experience.description}</p>
+    <p class="meta">${experience.duration}</p>
+    <button class="button ghost" data-action="detail" data-id="${experience.id}">Peek inside</button>
+    <button class="button primary" data-action="add" data-title="${experience.title}">Add to itinerary</button>
+  `;
+  return card;
+};
+
+const renderExperiences = (filter = 'all') => {
+  experienceGrid.innerHTML = '';
+  const filtered =
+    filter === 'all'
+      ? experienceData
+      : experienceData.filter((exp) => exp.category === filter);
+
+  filtered.forEach((experience) => {
+    experienceGrid.appendChild(experienceCard(experience));
+  });
+
+  if (!filtered.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'No experiences yet in this mood—check back soon!';
+    experienceGrid.appendChild(empty);
+  }
+};
+
+const renderDetail = (experienceId) => {
+  const experience = experienceData.find((exp) => exp.id === experienceId);
+  detailContainer.innerHTML = '';
+
+  if (!experience) return;
+
+  const detail = document.createElement('article');
+  detail.className = 'detail-card';
+  detail.innerHTML = `
+    <h3>${experience.title}</h3>
+    <p>${experience.description}</p>
+    <p><strong>Insider pairing:</strong> ${experience.addOn}</p>
+  `;
+  detailContainer.appendChild(detail);
+};
+
+const sortItinerary = () => {
+  itineraryItems.sort((a, b) => {
+    if (a.day === b.day) {
+      return a.time.localeCompare(b.time);
+    }
+    return a.day - b.day;
+  });
+};
+
+const plannerSummaryText = () => {
+  if (!itineraryItems.length) {
+    return 'No plans yet—start dreaming!';
+  }
+
+  const days = new Set(itineraryItems.map((item) => item.day));
+  return `Curating ${itineraryItems.length} experiences across ${days.size} day${
+    days.size > 1 ? 's' : ''
+  }.`;
+};
+
+const renderItinerary = () => {
+  itineraryList.innerHTML = '';
+  itineraryEmpty.style.display = itineraryItems.length ? 'none' : 'block';
+  plannerSummary.textContent = plannerSummaryText();
+
+  itineraryItems.forEach((item) => {
+    const li = document.createElement('li');
+    li.className = 'plan-item';
+    li.dataset.id = item.id;
+    li.innerHTML = `
+      <span class="day">Day ${item.day}</span>
+      <span class="time">${item.time}</span>
+      <div>
+        <p>${item.activity}</p>
+      </div>
+      <button type="button" aria-label="Remove">×</button>
+    `;
+    itineraryList.appendChild(li);
+  });
+};
+
+const addItineraryItem = ({ day, time, activity }) => {
+  const entry = {
+    id: crypto.randomUUID(),
+    day: Number(day),
+    time,
+    activity
+  };
+  itineraryItems.push(entry);
+  sortItinerary();
+  saveItinerary();
+  renderItinerary();
+};
+
+const removeItineraryItem = (id) => {
+  itineraryItems = itineraryItems.filter((item) => item.id !== id);
+  saveItinerary();
+  renderItinerary();
+};
+
+const populateNeighborhoods = () => {
+  neighborhoods.forEach((hood) => {
+    const card = document.createElement('article');
+    card.className = 'card';
+    card.innerHTML = `
+      <div class="meta">${hood.mood}</div>
+      <h3>${hood.name}</h3>
+      <p>${hood.description}</p>
+      <p><strong>Signature moment:</strong> ${hood.highlight}</p>
+    `;
+    neighborhoodGrid.appendChild(card);
+  });
+};
+
+const surpriseMe = () => {
+  const ideas =
+    surpriseItineraries[Math.floor(Math.random() * surpriseItineraries.length)];
+  if (!ideas) return;
+
+  itineraryItems = ideas.map((idea, index) => ({
+    id: crypto.randomUUID(),
+    day: Math.min(index + 1, 7),
+    time: index === 0 ? '08:30' : index === ideas.length - 1 ? '20:00' : '14:00',
+    activity: idea
+  }));
+  sortItinerary();
+  saveItinerary();
+  renderItinerary();
+};
+
+const handleExperienceClick = (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+
+  const action = target.dataset.action;
+
+  if (action === 'detail') {
+    renderDetail(target.dataset.id);
+  }
+
+  if (action === 'add') {
+    addItineraryItem({ day: 1, time: '12:00', activity: target.dataset.title });
+  }
+};
+
+const handlePlanSubmit = (event) => {
+  event.preventDefault();
+  const formData = new FormData(planForm);
+  const day = formData.get('day');
+  const time = formData.get('time');
+  const activity = formData.get('activity');
+
+  if (!day || !time || !activity) return;
+
+  addItineraryItem({ day, time, activity });
+  planForm.reset();
+};
+
+const handleItineraryClick = (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  if (target.tagName.toLowerCase() !== 'button') return;
+
+  const id = target.parentElement?.dataset.id;
+  if (!id) return;
+
+  removeItineraryItem(id);
+};
+
+const handleFilterClick = (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLButtonElement)) return;
+
+  filterButtons.forEach((button) => button.classList.remove('active'));
+  target.classList.add('active');
+  renderExperiences(target.dataset.filter ?? 'all');
+};
+
+const init = () => {
+  renderExperiences();
+  populateNeighborhoods();
+  loadItinerary();
+  sortItinerary();
+  renderItinerary();
+  yearSpan.textContent = new Date().getFullYear();
+};
+
+experienceGrid.addEventListener('click', handleExperienceClick);
+filterButtons.forEach((button) =>
+  button.addEventListener('click', handleFilterClick)
+);
+itineraryList.addEventListener('click', handleItineraryClick);
+planForm.addEventListener('submit', handlePlanSubmit);
+surpriseButton.addEventListener('click', surpriseMe);
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Paristuan · Boutique Paris Travel Planner</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Work+Sans:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-content">
+        <div class="brand">
+          <span class="brand-mark">Paristuan</span>
+          <p class="brand-tagline">Curating intimate Parisian escapes</p>
+        </div>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="#highlights">Experiences</a>
+          <a href="#itinerary">Planner</a>
+          <a href="#neighborhoods">Neighborhoods</a>
+          <a href="#insights">Insights</a>
+          <a class="cta" href="#contact">Plan your stay</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">Tailored for the curious traveler</p>
+            <h1>Design a soulful Paris itinerary with handpicked experiences.</h1>
+            <p>
+              From hidden ateliers to candlelit bistros, Paristuan curates the
+              essence of Paris so you can savor every moment. Build your
+              itinerary, discover insider insights, and wander with confidence.
+            </p>
+            <div class="hero-actions">
+              <a class="button primary" href="#itinerary">Start planning</a>
+              <button class="button ghost" type="button" id="surprise-me">
+                Surprise me
+              </button>
+            </div>
+          </div>
+          <figure class="hero-media">
+            <img
+              src="https://images.unsplash.com/photo-1502602898657-3e91760cbb34?auto=format&fit=crop&w=1350&q=80"
+              alt="Evening view of the Eiffel Tower over Paris rooftops"
+            />
+            <figcaption>
+              Capture the golden hour from Montmartre before a jazz soirée.
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section id="highlights" class="section">
+        <div class="container section-heading">
+          <div>
+            <p class="eyebrow">Curated experiences</p>
+            <h2>Choose your vibe</h2>
+            <p>
+              Filter through our boutique selection to find the experiences that
+              resonate with your travel style. Add any idea directly to your
+              itinerary.
+            </p>
+          </div>
+          <div class="filters" role="group" aria-label="Experience filters">
+            <button class="filter-button active" data-filter="all">All</button>
+            <button class="filter-button" data-filter="culture">Culture</button>
+            <button class="filter-button" data-filter="cuisine">Cuisine</button>
+            <button class="filter-button" data-filter="art">Art & Design</button>
+            <button class="filter-button" data-filter="nightlife">Nightlife</button>
+          </div>
+        </div>
+        <div class="container">
+          <div class="grid" id="experience-grid" aria-live="polite"></div>
+        </div>
+        <div class="container" id="experience-details" aria-live="polite"></div>
+      </section>
+
+      <section id="itinerary" class="section soft">
+        <div class="container section-heading">
+          <div>
+            <p class="eyebrow">Itinerary planner</p>
+            <h2>Shape your perfect day</h2>
+            <p>
+              Capture your must-do moments across the week. We will keep them in
+              order and ready for the journey.
+            </p>
+          </div>
+          <div class="planner-summary" id="planner-summary" aria-live="polite">
+            No plans yet—start dreaming!
+          </div>
+        </div>
+        <div class="container planner">
+          <form id="plan-form" class="plan-form" autocomplete="off">
+            <div class="field">
+              <label for="plan-day">Day</label>
+              <select id="plan-day" name="day" required>
+                <option value="">Select</option>
+                <option value="1">Day 1</option>
+                <option value="2">Day 2</option>
+                <option value="3">Day 3</option>
+                <option value="4">Day 4</option>
+                <option value="5">Day 5</option>
+                <option value="6">Day 6</option>
+                <option value="7">Day 7</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="plan-time">Time</label>
+              <input id="plan-time" name="time" type="time" required />
+            </div>
+            <div class="field field-wide">
+              <label for="plan-activity">Experience</label>
+              <input
+                id="plan-activity"
+                name="activity"
+                type="text"
+                placeholder="Ex: Sunrise picnic at the Tuileries"
+                required
+              />
+            </div>
+            <button class="button primary" type="submit">Add to itinerary</button>
+          </form>
+
+          <div class="itinerary-list" aria-live="polite">
+            <ol id="itinerary-list" class="plans"></ol>
+            <p class="empty-state" id="itinerary-empty">Your itinerary is waiting for its first note.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="neighborhoods" class="section">
+        <div class="container section-heading">
+          <div>
+            <p class="eyebrow">Neighborhood spotlight</p>
+            <h2>Discover pockets of charm</h2>
+            <p>
+              Each arrondissement carries its own tempo. Tap through the
+              highlights to reveal the ambience that fits your stay.
+            </p>
+          </div>
+        </div>
+        <div class="container">
+          <div class="grid" id="neighborhood-grid" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section id="insights" class="section soft">
+        <div class="container section-heading">
+          <div>
+            <p class="eyebrow">Local insights</p>
+            <h2>Before you wander</h2>
+            <p>
+              Practical advice gathered from locals to keep your Paris adventure
+              seamless.
+            </p>
+          </div>
+        </div>
+        <div class="container tips-grid">
+          <article class="tip">
+            <h3>Reserve ahead</h3>
+            <p>
+              Boutique restaurants book quickly. Reserve dinner spots two weeks
+              out, especially for weekend evenings.
+            </p>
+          </article>
+          <article class="tip">
+            <h3>Embrace the tempo</h3>
+            <p>
+              Many shops pause midday. Plan cultural visits for mornings and
+              evenings, leaving afternoons for leisurely cafés.
+            </p>
+          </article>
+          <article class="tip">
+            <h3>Travel light</h3>
+            <p>
+              Parisian streets often include cobblestones and staircases. Opt for
+              a compact suitcase and comfortable footwear.
+            </p>
+          </article>
+          <article class="tip">
+            <h3>Mind the etiquette</h3>
+            <p>
+              Start every conversation with a warm “Bonjour” and keep voices at a
+              gentle tone in intimate venues.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="contact" class="section">
+        <div class="container section-heading">
+          <div>
+            <p class="eyebrow">Concierge connection</p>
+            <h2>Craft something unforgettable</h2>
+            <p>
+              Tell us the mood of your trip and we will send a bespoke
+              collection of recommendations.
+            </p>
+          </div>
+        </div>
+        <div class="container contact-card">
+          <form class="contact-form">
+            <label>
+              Name
+              <input type="text" name="name" placeholder="Camille" required />
+            </label>
+            <label>
+              Email
+              <input type="email" name="email" placeholder="you@example.com" required />
+            </label>
+            <label>
+              Trip vibe
+              <select name="vibe">
+                <option value="romance">Romantic escape</option>
+                <option value="culture">Culture & history</option>
+                <option value="food">Culinary adventures</option>
+                <option value="fashion">Fashion-forward</option>
+              </select>
+            </label>
+            <label>
+              Message
+              <textarea name="message" rows="4" placeholder="Share your dream moments..."></textarea>
+            </label>
+            <button class="button primary" type="submit">Request curation</button>
+          </form>
+          <aside class="contact-aside">
+            <h3>Included concierge perks</h3>
+            <ul>
+              <li>Tailored itinerary PDF</li>
+              <li>Restaurant reservation support</li>
+              <li>Exclusive atelier introductions</li>
+              <li>Insider-only evening salon invites</li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <span class="brand-mark">Paristuan</span>
+          <p>Crafted with amour for discerning explorers.</p>
+        </div>
+        <div>
+          <h4>Stay inspired</h4>
+          <form class="newsletter-form">
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input
+              id="newsletter-email"
+              type="email"
+              name="email"
+              placeholder="bonjour@example.com"
+            />
+            <button class="button ghost" type="submit">Join</button>
+          </form>
+        </div>
+        <div>
+          <h4>Follow the journey</h4>
+          <ul class="footer-links">
+            <li><a href="#">Instagram</a></li>
+            <li><a href="#">Pinterest</a></li>
+            <li><a href="#">Spotify playlist</a></li>
+          </ul>
+        </div>
+      </div>
+      <p class="footer-note">© <span id="year"></span> Paristuan. All rights reserved.</p>
+    </footer>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,564 @@
+:root {
+  color-scheme: light;
+  --font-display: 'Playfair Display', serif;
+  --font-body: 'Work Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-background: #fdf9f5;
+  --color-soft: #f6efe8;
+  --color-accent: #d59c7b;
+  --color-accent-dark: #b67d5c;
+  --color-text: #2f2a28;
+  --color-muted: #6f6460;
+  --color-border: #e1d7ce;
+  --shadow-soft: 0 20px 45px rgba(47, 42, 40, 0.12);
+  --shadow-card: 0 12px 30px rgba(47, 42, 40, 0.1);
+  --radius: 22px;
+  scroll-behavior: smooth;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  line-height: 1.6;
+  background: var(--color-background);
+  color: var(--color-text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: var(--radius);
+}
+
+.container {
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+}
+
+.section {
+  padding: clamp(4rem, 8vw, 6rem) 0;
+}
+
+.section.soft {
+  background: var(--color-soft);
+}
+
+.section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.section-heading h2 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 3.6vw, 2.8rem);
+  margin: 0.4rem 0 0.6rem;
+}
+
+.section-heading p {
+  max-width: 36ch;
+  margin: 0;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.button {
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 0.8rem 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-family: var(--font-body);
+  letter-spacing: 0.02em;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+}
+
+.button.primary {
+  background: var(--color-accent);
+  color: white;
+  box-shadow: var(--shadow-soft);
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  background: var(--color-accent-dark);
+}
+
+.button.ghost {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.button.ghost:hover,
+.button.ghost:focus {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(253, 249, 245, 0.95);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(213, 156, 123, 0.15);
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.2rem 0;
+  gap: 1.5rem;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.brand-mark {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.brand-tagline {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.site-nav a {
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.4rem 0.6rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  background: rgba(213, 156, 123, 0.1);
+}
+
+.site-nav .cta {
+  background: rgba(213, 156, 123, 0.15);
+  border: 1px solid rgba(213, 156, 123, 0.35);
+}
+
+.hero {
+  padding: clamp(6rem, 10vw, 8rem) 0 clamp(3rem, 6vw, 5rem);
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+}
+
+.hero-copy h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 4.4vw, 3.4rem);
+  margin-bottom: 1.5rem;
+}
+
+.hero-copy p {
+  margin: 0 0 1.5rem;
+  color: var(--color-muted);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero-media figcaption {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.filter-button {
+  border: 1px solid var(--color-border);
+  background: white;
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.filter-button.active,
+.filter-button:hover,
+.filter-button:focus {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.8rem;
+}
+
+.card {
+  background: white;
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 42px rgba(47, 42, 40, 0.14);
+}
+
+.card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.card .meta {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.card button {
+  align-self: flex-start;
+}
+
+#experience-details {
+  margin-top: 2.5rem;
+}
+
+.detail-card {
+  background: white;
+  border-radius: var(--radius);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.detail-card h3 {
+  margin-top: 0;
+  font-family: var(--font-display);
+}
+
+.planner {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.plan-form {
+  background: white;
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.field label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field select,
+.field input,
+textarea {
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  padding: 0.75rem 1rem;
+  font-family: inherit;
+  font-size: 1rem;
+  background: #fff;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.field-wide {
+  grid-column: 1 / -1;
+}
+
+.itinerary-list {
+  background: white;
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.plans {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.plan-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  background: var(--color-soft);
+}
+
+.plan-item .time {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.plan-item .day {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+}
+
+.plan-item button {
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.plan-item button:hover,
+.plan-item button:focus {
+  color: var(--color-accent);
+}
+
+.empty-state {
+  margin: 0;
+  color: var(--color-muted);
+  text-align: center;
+}
+
+.planner-summary {
+  background: white;
+  border-radius: var(--radius);
+  padding: 1.4rem 2rem;
+  box-shadow: var(--shadow-card);
+  font-weight: 500;
+}
+
+.tips-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.tip {
+  background: white;
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+}
+
+.contact-card {
+  background: white;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  padding: clamp(2rem, 3vw, 3rem);
+}
+
+.contact-form {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.contact-form label {
+  display: grid;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.contact-form input,
+.contact-form textarea,
+.contact-form select {
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  padding: 0.75rem 1rem;
+  font-family: inherit;
+  font-size: 1rem;
+}
+
+.contact-aside h3 {
+  margin-top: 0;
+  font-family: var(--font-display);
+}
+
+.contact-aside ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.contact-aside li::before {
+  content: '•';
+  color: var(--color-accent);
+  margin-right: 0.5rem;
+}
+
+.site-footer {
+  padding: 3rem 0 2rem;
+  background: #fff;
+  border-top: 1px solid rgba(213, 156, 123, 0.2);
+  margin-top: 4rem;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.footer-grid p {
+  margin: 0.5rem 0 0;
+  color: var(--color-muted);
+}
+
+.footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.newsletter-form {
+  display: flex;
+  gap: 0.8rem;
+}
+
+.newsletter-form input {
+  flex: 1;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  padding: 0.7rem 1rem;
+}
+
+.footer-note {
+  text-align: center;
+  color: var(--color-muted);
+  margin-top: 3rem;
+  font-size: 0.9rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .site-nav {
+    justify-content: flex-end;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .plan-item {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .plan-item button {
+    justify-self: center;
+  }
+
+  .newsletter-form {
+    flex-direction: column;
+  }
+
+  .newsletter-form button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the empty placeholder with a boutique-themed Paristuan landing page
- add curated experience explorer, itinerary planner, and neighborhood highlights
- style the site with custom typography, responsive layouts, and interactive behaviors

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e68927253c8321ad9f11cc6aaedf04